### PR TITLE
Report "binary files differ"

### DIFF
--- a/hamstercage/__main__.py
+++ b/hamstercage/__main__.py
@@ -430,15 +430,14 @@ class Hamstercage:
         try:
             with open(target) as f:
                 t = f.readlines()
-        except Exception as e:
-            print(f"warning: unable to diff {target}: {e}", file=sys.stderr)
-            return ""
-        try:
             with open(repo) as f:
                 r = f.readlines()
-        except Exception as e:
-            print(f"warning: unable to diff {repo}: {e}", file=sys.stderr)
-            return ""
+        except UnicodeDecodeError as e:
+            return ["binary files differ"]
+        if r[-1][-1:] != "\n":
+            r[-1] += "\n"
+        if t[-1][-1:] != "\n":
+            t[-1] += "\n"
         return unified_diff(
             r,
             t,

--- a/hamstercage/__main__.py
+++ b/hamstercage/__main__.py
@@ -258,13 +258,11 @@ class Hamstercage:
         manifest.dump()
         return 0
 
-    def list(self, args, file=None):
+    def list(self, args):
         """
         Print a list of all manifest entries
         :return:
         """
-        if file is None:
-            out = sys.stdout
         self._load_manifest()
         self.files = args.files
         items = {}
@@ -275,7 +273,7 @@ class Hamstercage:
                 items[target] = ListEntry(e, repo, t)
         if args.long == 0:
             for path in sorted(items):
-                print(path, file=file)
+                print(path)
         else:
             lines = []
             for path in sorted(items):
@@ -316,7 +314,7 @@ class Hamstercage:
                         name,
                     ]
                 )
-            print_table(lines, align=["<", "<", "<", "<", ">"], file=file)
+            print_table(lines, align=["<", "<", "<", "<", ">"])
         # widths = [0] * 8
         # align = ["<", "<", "<", "<", ">", "<", "<", "<"]
         # for line in lines:

--- a/hamstercage/tests/test_hamstercage.py
+++ b/hamstercage/tests/test_hamstercage.py
@@ -302,8 +302,10 @@ class TestHamstercage(TestCase):
         self.file_path.unlink()
 
         args = Args(files=[])
-        r = dut.diff(args)
+        with redirect_stdout(io.StringIO()) as stdout:
+            r = dut.diff(args)
         self.assertEqual(1, r)
+        self.assertEqual("missing\n", stdout.getvalue()[-8:])
 
     def test_diff_unchanged(self):
         dut = self.perform_add_many()
@@ -373,10 +375,10 @@ class TestHamstercage(TestCase):
 
     def test_list_short(self):
         dut = self.perform_add_many()
-        out = io.StringIO()
 
         args = Args(files=[], long=0)
-        r = dut.list(args, file=out)
+        with redirect_stdout(io.StringIO()) as stdout:
+            r = dut.list(args)
         self.assertEqual(0, r)
 
         t = datetime.fromtimestamp(os.stat(self.file_path).st_mtime).strftime("%H:%M")
@@ -387,15 +389,15 @@ class TestHamstercage(TestCase):
                 str(self.file_path),
                 "",
             ],
-            out.getvalue().split("\n"),
+            stdout.getvalue().split("\n"),
         )
 
     def test_list_long(self):
         dut = self.perform_add_many()
-        out = io.StringIO()
 
         args = Args(files=[], long=1)
-        r = dut.list(args, file=out)
+        with redirect_stdout(io.StringIO()) as stdout:
+            r = dut.list(args)
         self.assertEqual(0, r)
 
         ts_dir = datetime.fromtimestamp(os.stat(self.dir_path).st_mtime).strftime(
@@ -414,15 +416,15 @@ class TestHamstercage(TestCase):
                 f" \t-rw-r--r--\t{self.user}\t{self.group}\t13\t{ts_file}\tall\t{self.file_path}",
                 "",
             ],
-            out.getvalue().split("\n"),
+            stdout.getvalue().split("\n"),
         )
 
     def test_list_long_one(self):
         dut = self.perform_add_many()
-        out = io.StringIO()
 
         args = Args(files=[str(self.file_path)], long=1)
-        r = dut.list(args, file=out)
+        with redirect_stdout(io.StringIO()) as stdout:
+            r = dut.list(args)
         self.assertEqual(0, r)
 
         ts_file = datetime.fromtimestamp(os.stat(self.file_path).st_mtime).strftime(
@@ -433,21 +435,23 @@ class TestHamstercage(TestCase):
                 f" \t-rw-r--r--\t{self.user}\t{self.group}\t13\t{ts_file}\tall\t{self.file_path}",
                 "",
             ],
-            out.getvalue().split("\n"),
+            stdout.getvalue().split("\n"),
         )
 
     def test_list_long_missing(self):
         dut = self.perform_add_many()
-        out = io.StringIO()
         self.file_path.unlink()
 
         args = Args(files=[str(self.file_path)], long=1)
-        r = dut.list(args, file=out)
+        with redirect_stdout(io.StringIO()) as stdout:
+            r = dut.list(args)
         self.assertEqual(0, r)
 
     def test_main(self):
         dut = self.prepare_hamstercage()
-        dut.main([])
+        with redirect_stdout(io.StringIO()) as stdout:
+            r = dut.main([])
+        self.assertEqual(64, r)
 
     def test_normalize_target_path(self):
         dut = self.prepare_hamstercage()


### PR DESCRIPTION
When comparing files that contain illegal UTF-8 sequences, report "binary files differ" instead of an error message.

While here, fix a diff issue when one or both of the files do not end in a line feed.

Closes #5 