### PR TITLE
When target is a regular file instead of link list it with "!"

### DIFF
--- a/hamstercage/__main__.py
+++ b/hamstercage/__main__.py
@@ -302,7 +302,9 @@ class Hamstercage:
                 elif isinstance(entry, SymlinkEntry):
                     name = name + " -> " + entry.target
                     type = "l"
-                    if path.exists() and os.readlink(path) != entry.target:
+                    if path.exists() and path.is_file():
+                        status = "!"
+                    elif path.exists() and os.readlink(path) != entry.target:
                         status = "*"
                 lines.append(
                     [

--- a/hamstercage/tests/test_hamstercage.py
+++ b/hamstercage/tests/test_hamstercage.py
@@ -427,6 +427,26 @@ class TestHamstercage(TestCase):
         r = dut.list(args, file=out)
         self.assertEqual(0, r)
 
+    def test_list_long_regular_instead_of_link(self):
+        dut = self.perform_add_many()
+        out = io.StringIO()
+        self.link_path.unlink()
+        self.link_path.write_text("Hello, world!", "utf-8")
+
+        args = Args(files=[str(self.link_path)], long=1)
+        r = dut.list(args, file=out)
+        self.assertEqual(0, r)
+        ts_link = datetime.fromtimestamp(os.stat(self.link_path).st_mtime).strftime(
+            "%H:%M"
+        )
+        self.assertEqual(
+            [
+                f"!\tlrw-r--r--\troot\troot\t13\t{ts_link}\tall\t{self.link_path} -> /dev/null",
+                "",
+            ],
+            out.getvalue().split("\n"),
+        )
+
     def test_main(self):
         dut = self.prepare_hamstercage()
         dut.main([])


### PR DESCRIPTION
When the manifest entry is a link, but the path in the target is a regular file, mark the line with "!".

Closes #2 